### PR TITLE
remove the rendering from workout create to prevent the errors

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -31,8 +31,6 @@ class WorkoutsController < ApplicationController
       @workout = Workout.new(workout_params)
       if @workout.save
         redirect_to account_path, notice: "Your workout has been scheduled!"
-      else
-        render 'new', status: :unprocessable_entity
       end
     end
   end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -3,6 +3,8 @@ class Workout < ApplicationRecord
   # belongs_to :programme, optional: true
   has_many :logs, dependent: :destroy
   has_many :split_exercises, through: :logs
+  validates :date, presence: true
+  validates :split, presence: true
 
   def start_time
     # set a default start time of each workout for the calendar view

--- a/app/views/workouts/new.html.erb
+++ b/app/views/workouts/new.html.erb
@@ -3,7 +3,7 @@
 <div class="form-container">
   <%= simple_form_for @workout do |f| %>
     <div class="form-inputs">
-      <%= f.association :split, collection: @splits, prompt: "Choose a split", value_method: :id, label_method: :category  %>
+      <%= f.association :split, collection: @splits, prompt: "Choose a split", value_method: :id, label_method: :category, input_html: { class: "form-control", required: true }, error: "please choose a split"  %>
       <%= f.input :date,
             as: :string,
             input_html: { data: { controller: "datepicker" } } %>


### PR DESCRIPTION
This pull request focuses on improving the validation and user experience for creating workouts. The most important changes include adding validation for the `Workout` model, enhancing the form for creating workouts, and modifying the controller to handle form submission more effectively.

### Validation improvements:

* [`app/models/workout.rb`](diffhunk://#diff-2a57aca85b3b35d1ad6fca04d8119f91fd064a2453453963da0f0c3e0ef8418eR6-R7): Added presence validation for `date` and `split` attributes to ensure that these fields are filled out when creating a workout.

### Form enhancements:

* [`app/views/workouts/new.html.erb`](diffhunk://#diff-12435f5e365df22892e6e250dbd1a5f838690a357165981e2a24dcac54f97383L6-R6): Updated the form to include required fields and custom error messages, improving the user experience by providing immediate feedback if the form is incomplete.

### Controller changes:

* [`app/controllers/workouts_controller.rb`](diffhunk://#diff-891ab8165b2ad11a35956b36ce801bf350da1b57cc2137703bf3c3a975141673L34-L35): Removed the fallback render for the 'new' action when the workout creation fails, simplifying the controller logic.